### PR TITLE
Add pyo3 Rust lib example

### DIFF
--- a/pyo3_sum/Cargo.toml
+++ b/pyo3_sum/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pyo3_sum"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "pyo3_sum"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.21.0", features = ["extension-module"] }

--- a/pyo3_sum/src/lib.rs
+++ b/pyo3_sum/src/lib.rs
@@ -1,0 +1,13 @@
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+
+#[pyfunction]
+fn sum_floats(values: Vec<f64>) -> f64 {
+    values.iter().sum()
+}
+
+#[pymodule]
+fn pyo3_sum(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(sum_floats, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a pyo3-based Rust library example
- expose `sum_floats` to Python

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6842f7067074833383a060009b14c1be